### PR TITLE
Add fix for the optional reason in a HTTP response

### DIFF
--- a/lib/Http/Response.php
+++ b/lib/Http/Response.php
@@ -285,7 +285,8 @@ class Response
         // Split headers part to lines
         $headerLines = preg_split('|[\r\n]+|m', $headerLines);
         $status = array_shift($headerLines);
-        if (preg_match("|^HTTP/([\d\.x]+) (\d+) ([^\r\n]+)|", $status, $m)) {
+        // Added a fix for servers that forget to answer with "OK": HTTP/1.1 200 OK
+        if (preg_match("|^HTTP/([\d\.x]+) (\d+) ([^\r\n]*)|", $status, $m)) {
             $version = $m[1];
             $status = $m[2];
             $message = $m[3];


### PR DESCRIPTION
So it also allows this response from an endpoint: "HTTP/1.1 200" next to "HTTP/1.1 200 OK"